### PR TITLE
use webmockr then

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,18 +36,19 @@ Imports:
     lubridate,
     magrittr,
     rlang,
-    tidyr
+    tidyr,
+    vcr (>= 0.4.2.93)
 Suggests:
     ggplot2,
     knitr,
     rmarkdown,
     rworldmap,
     testthat (>= 2.1.0),
-    vcr (>= 0.5.0),
     viridis
 Encoding: UTF-8
 LazyData: TRUE
 RoxygenNote: 7.0.2
 Roxygen: list(markdown = TRUE)
-Remotes: 
-    ropensci/webmockr
+Remotes:  
+    ropensci/webmockr,
+    ropensci/vcr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,6 +30,7 @@ URL: https://docs.ropensci.org/ropenaq,
 BugReports: http://github.com/ropensci/ropenaq/issues
 Imports:
     crul,
+    webmockr (>= 0.6.2.92),
     dplyr,
     jsonlite,
     lubridate,
@@ -37,7 +38,6 @@ Imports:
     rlang,
     tidyr
 Suggests:
-    webmockr (>= 0.6.2),
     ggplot2,
     knitr,
     rmarkdown,
@@ -49,5 +49,5 @@ Encoding: UTF-8
 LazyData: TRUE
 RoxygenNote: 7.0.2
 Roxygen: list(markdown = TRUE)
-Remotes:  
+Remotes: 
     ropensci/webmockr

--- a/R/utils.R
+++ b/R/utils.R
@@ -238,6 +238,7 @@ getResults_bypage <- function(urlAQ, argsList){
   argsList <- argsList[argsList != ""]
 
   onwait <- function(resp, wait_time) {
+    message("Checking status")
     status <- get_status()
 
     if (!status %in% c("green", "yellow", "unknown", "unavailable")) {
@@ -356,6 +357,7 @@ functionParameters <- function(resTable) {
 
 # dates abbreviation
 func_date_headers <- function(date){
+
   date <- strsplit(date, ",")[[1]][2]
   date <- gsub("Jan", "01", date)
   date <- gsub("Feb", "02", date)

--- a/tests/testthat/test-test-error.R
+++ b/tests/testthat/test-test-error.R
@@ -1,4 +1,4 @@
-test_that("API errors, status too", {
+test_that("API endoint errors, status API errors too", {
   library("magrittr")
   webmockr::enable()
 
@@ -13,7 +13,7 @@ test_that("API errors, status too", {
   webmockr::disable()
 })
 
-test_that("API errors once status not", {
+test_that("API errors twice, status not", {
   library("magrittr")
   # when not all is well
   webmockr::enable()

--- a/tests/testthat/test-test-error.R
+++ b/tests/testthat/test-test-error.R
@@ -19,8 +19,10 @@ test_that("API errors once status not", {
   webmockr::enable()
 
   webmockr::stub_request("get", paste0(base_url(), "countries?limit=0&page=1")) %>%
-    webmockr::to_return(status = 404, body = "retry!", times = 1) %>%
-    webmockr::to_return(status = 200, body = '{"meta":{"name":"openaq-api","license":"CC BY 4.0","website":"https://docs.openaq.org/","page":1,"limit":100,"found":98}}') # here I want to use a real response and cassette
+    webmockr::to_return(status = 404, body = "retry!", times = 2) %>%
+    webmockr::to_return(status = 200,
+                        headers = list(date = "Thu, 09 Apr 2020 14:20:43 GMT"),
+                        body = '{"meta":{"name":"openaq-api","license":"CC BY 4.0","website":"https://docs.openaq.org/","page":1,"limit":100,"found":98}}') # here I want to use a real response and cassette
   # how do I do that?
 
   webmockr::stub_request("get", status_url()) %>%

--- a/tests/testthat/test-test-error.R
+++ b/tests/testthat/test-test-error.R
@@ -1,0 +1,39 @@
+test_that("API errors, status too", {
+  library("magrittr")
+  webmockr::enable()
+
+  webmockr::stub_request("get", paste0(base_url(), "countries?limit=0&page=1")) %>%
+    webmockr::to_return(status = 404)
+
+  webmockr::stub_request("get", status_url()) %>%
+    webmockr::to_return(body = '{"meta":{"name":"openaq-api","license":"CC BY 4.0","website":"https://docs.openaq.org/"},"results":{"healthStatus":"red"}}')
+
+  expect_error(aq_countries(), "uh oh")
+
+  webmockr::disable()
+})
+
+test_that("API errors once status not", {
+  library("magrittr")
+  # when not all is well
+  webmockr::enable()
+
+  webmockr::stub_request("get", paste0(base_url(), "countries?limit=0&page=1")) %>%
+    webmockr::to_return(status = 404, body = "retry!", times = 1) %>%
+    webmockr::to_return(status = 200, body = '{"meta":{"name":"openaq-api","license":"CC BY 4.0","website":"https://docs.openaq.org/","page":1,"limit":100,"found":98}}') # here I want to use a real response and cassette
+  # how do I do that?
+
+  webmockr::stub_request("get", status_url()) %>%
+    webmockr::to_return(body = '{"meta":{"name":"openaq-api","license":"CC BY 4.0","website":"https://docs.openaq.org/"},"results":{"healthStatus":"green"}}')
+
+  webmockr::stub_request("get", paste0(base_url(), "countries?limit=10000")) %>%
+    webmockr::to_return(status = 200,
+                        headers = list(date = "Thu, 09 Apr 2020 14:20:43 GMT"),
+                        body = '{"meta":{"name":"openaq-api","license":"CC BY 4.0","website":"https://docs.openaq.org/","page":1,"limit":100,"found":98},"results":[{"code":"AD","count":118490,"locations":3,"cities":2,"name":"Andorra"},{"code":"AE","count":77527,"locations":4,"cities":3,"name":"United Arab Emirates"}]}')
+
+  expect_message(countries <- aq_countries(), "Checking status")
+  expect_is(countries, "tbl_df")
+
+  webmockr::disable()
+})
+


### PR DESCRIPTION
I'm trying to have a mix of webmockr stubs, and real responses. How could I do that?

For reference when calling aq_countries(), 
* there's a first call to the API endpoint with limit=0 just to get the number of results;
* then there's a second call to the API endpoint with limit=10000.
* if there's a non 200 status, before retrying, `get_status()` (the API status, not an HTTP code) is called.